### PR TITLE
Copy all dml zip files directly, binaries/mod_loader was being skipped

### DIFF
--- a/game-warhammer40kdarktide/index.js
+++ b/game-warhammer40kdarktide/index.js
@@ -156,22 +156,13 @@ async function installMod(files) {
 }
 
 async function installDML(files) {
-  const gamePath = await queryPath();
-  const mod_load_order_file_maker = files.find(
-    (file) => path.extname(file).toLowerCase() === BAT_FILE_EXT
-  );
-  const idx = mod_load_order_file_maker.indexOf(
-    path.basename(mod_load_order_file_maker)
-  );
-  const rootPath = path.dirname(mod_load_order_file_maker);
-  const filtered = files.filter(
-    (file) => file.indexOf(rootPath) !== -1 && !file.endsWith(path.sep)
-  );
-  const instructions = filtered.map((file) => {
+  // Copy all files directly into game folder
+  const instructions = files.filter(file => !file.endsWith(path.sep))
+  .map((file) => {
     return {
       type: "copy",
       source: file,
-      destination: file.substr(idx),
+      destination: file,
     };
   });
   return { instructions };


### PR DESCRIPTION
I wasn't able to successfully install DML, it would leave out mod_loader each time.

Perhaps I missed something, but with this change, it works reliably for me.