### PR TITLE
Automatically dtkit-patch --patch on deploy and --unpatch on purge

### DIFF
--- a/game-warhammer40kdarktide/index.js
+++ b/game-warhammer40kdarktide/index.js
@@ -1,5 +1,9 @@
 const path = require("path");
-const { fs, log, util } = require("vortex-api");
+const { fs, log, util, selectors } = require("vortex-api");
+
+const child_process = require("child_process");
+
+const { profile } = require("console");
 
 // Nexus Mods domain for the game. e.g. nexusmods.com/warhammer40kdarktide
 const GAME_ID = "warhammer40kdarktide";
@@ -37,7 +41,12 @@ const tools = [
   },
 ];
 
+// Not sure if there is a more elegant way to get this for patching later
+let GAME_PATH = null
+
 async function prepareForModding(discovery, api) {
+  GAME_PATH = discovery.path
+
   // Ensure the mods directory exists
   await fs.ensureDirWritableAsync(path.join(discovery.path, "mods"));
 
@@ -364,6 +373,25 @@ function main(context) {
       await serializeLoadOrder(context, loadOrder),
     toggleableEntries: true,
   });
+
+  // Didn't check if below events trigger on profiles for other games, so make sure it is for this
+  const is_game_profile = (profileId) => selectors.profileById(context.api.getState(), profileId)?.gameId === GAME_ID
+
+  const run_dtkit_patch_if_game_profile = (profileId, action) => {
+    if (is_game_profile(profileId) && GAME_PATH) {
+      // dtkit finds the game on its own, we don't care about cwd
+      child_process.spawnSync(path.join(GAME_PATH, 'tools', 'dtkit-patch.exe'), ['--'+action])
+    }
+  }
+
+  // Patch on deploy
+  context.api.events.on('did-deploy', (profileId) => {
+    run_dtkit_patch_if_game_profile(profileId, 'patch')
+  })
+  // Unpatch on purge
+  context.api.events.on('will-purge', (profileId) => {
+    run_dtkit_patch_if_game_profile(profileId, 'unpatch')
+  })
 
   return true;
 }

--- a/game-warhammer40kdarktide/index.js
+++ b/game-warhammer40kdarktide/index.js
@@ -42,10 +42,10 @@ const tools = [
 ];
 
 // Not sure if there is a more elegant way to get this for patching later
-let GAME_PATH = null
+let GAME_PATH = null;
 
 async function prepareForModding(discovery, api) {
-  GAME_PATH = discovery.path
+  GAME_PATH = discovery.path;
 
   // Ensure the mods directory exists
   await fs.ensureDirWritableAsync(path.join(discovery.path, "mods"));
@@ -375,15 +375,15 @@ function main(context) {
   });
 
   // Didn't check if below events trigger on profiles for other games, so make sure it is for this
-  const should_patch = (profileId) => (selectors.profileById(context.api.getState(), profileId)?.gameId === GAME_ID) && GAME_PATH
+  const should_patch = (profileId) => (selectors.profileById(context.api.getState(), profileId)?.gameId === GAME_ID) && GAME_PATH;
 
   // Patch on deploy
   context.api.onAsync('did-deploy', (profileId) => {
     if (should_patch(profileId)) {
       const proc = child_process.spawn(path.join(GAME_PATH, 'tools', 'dtkit-patch.exe'), ['--patch']);
-      proc.on('error', () => {})
+      proc.on('error', () => {});
     }
-  })
+  });
 
   // Unpatch on purge
   context.api.events.on('will-purge', (profileId) => {

--- a/game-warhammer40kdarktide/index.js
+++ b/game-warhammer40kdarktide/index.js
@@ -377,20 +377,20 @@ function main(context) {
   // Didn't check if below events trigger on profiles for other games, so make sure it is for this
   const is_game_profile = (profileId) => selectors.profileById(context.api.getState(), profileId)?.gameId === GAME_ID
 
-  const run_dtkit_patch_if_game_profile = (profileId, action) => {
+  const run_dtkit_patch_if_game_profile = (profileId, action, sync) => {
     if (is_game_profile(profileId) && GAME_PATH) {
       // dtkit finds the game on its own, we don't care about cwd
-      child_process.spawnSync(path.join(GAME_PATH, 'tools', 'dtkit-patch.exe'), ['--'+action])
+      child_process[sync ? "spawnSync" : "spawn"](path.join(GAME_PATH, 'tools', 'dtkit-patch.exe'), ['--'+action])
     }
   }
 
   // Patch on deploy
-  context.api.events.on('did-deploy', (profileId) => {
+  context.api.onAsync('did-deploy', (profileId) => {
     run_dtkit_patch_if_game_profile(profileId, 'patch')
   })
   // Unpatch on purge
   context.api.events.on('will-purge', (profileId) => {
-    run_dtkit_patch_if_game_profile(profileId, 'unpatch')
+    run_dtkit_patch_if_game_profile(profileId, 'unpatch', true)
   })
 
   return true;


### PR DESCRIPTION
This should automate patching/unpatching for users in most cases, and a redeploy will force a patch in any other case.